### PR TITLE
new: add an input to enable caching.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,20 @@ jobs:
       - name: Echo kernelrelease
         run: uname -a
         
+      - name: Store KERNEL_RELEASE
+        shell: bash
+        run: |
+          echo "KERNEL_RELEASE=$(uname -r)" >> $GITHUB_ENV  
+        
       - name: Check kernel sources (empty)
-        run: ls -la /usr/src  
+        run: ls -la /usr/src
     
-      - name: Test subsequent cached call
-        uses: ./
+      - name: Retrieve cached kernel sources
+        uses: actions/cache@v4
         with:
-          cache: 'true'
+          path: |
+            /usr/src/linux
+          key: ${{ runner.os }}-${{ runner.arch }}-${{env.KERNEL_RELEASE}}     
       
       - name: Check kernel sources again
-        run: ls -la /usr/src    
+        run: ls -la /usr/src   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test composite action
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+  workflow_dispatch:    
+
+jobs:
+  test-composite-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo kernelrelease
+        run: uname -a
+    
+      - name: Test action
+        uses: ./
+        with:
+          cache: 'true'
+          
+      - name: Check kernel sources
+        run: ls -la /usr/src
+  
+  test-composite-action-cached:
+    runs-on: ubuntu-latest
+    needs: test-composite-action
+    steps:
+      - name: Echo kernelrelease
+        run: uname -a
+        
+      - name: Check kernel sources (empty)
+        run: ls -la /usr/src  
+    
+      - name: Test subsequent cached call
+        uses: ./
+        with:
+          cache: 'true'
+      
+      - name: Check kernel sources again
+        run: ls -la /usr/src    

--- a/README.md
+++ b/README.md
@@ -17,31 +17,6 @@ You can then proceed with a DKMS or kmod build of whatever you require such as e
 
 Caching with [actions/cache](https://github.com/actions/cache) is likely to improve the speed of getting the Kernel sources, rather than fetching them directly from git.
 
-The following workflow factors in the OS, CPU archiecture and Kernel version into the cache key:
-
-```yaml
-    steps:
-      - name: Reset permissions of /usr/src for runner
-        run: |
-          sudo chown -R runner:docker /usr/src
-      - name: Set TARGET_ARCH
-        run: |
-          echo "TARGET_ARCH=$(uname -m)" >> $GITHUB_ENV
-      - name: Set KERNEL_VERSION
-        run: |
-          echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
-      - name: Cache Kernel sources
-        id: cache-kernel-sources
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/src/linux
-          key: ${{ runner.os }}-${{ env.TARGET_ARCH }}-${{env.KERNEL_VERSION}}
-
-      - if: ${{ steps.cache-kernel-sources.outputs.cache-hit != 'true' }}
-        uses: self-actuated/get-kernel-sources@master
-```
-
 For example:
 
 ```bash
@@ -49,3 +24,12 @@ Cache Size: ~434 MB (454865493 B)
 Cache saved successfully
 Cache saved with key: Linux-aarch64-6.1.90
 ```
+
+To enable caching, you just need to pass `cache: 'true'` input, eg:
+```yaml
+- uses: self-actuated/get-kernel-sources@master
+  with:
+    cache: 'true'
+```
+
+

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Cache saved successfully
 Cache saved with key: Linux-aarch64-6.1.90
 ```
 
-To enable caching, you just need to pass `cache: 'true'` input, eg:
+Caching is enabled by default; to disable it, you just need to pass `cache: 'false'` input, eg:
 ```yaml
 - uses: self-actuated/get-kernel-sources@master
   with:
-    cache: 'true'
+    cache: 'false'
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   cache:
     description: Whether to enable caching for the downloaded sources
     required: false
-    default: 'false'
+    default: 'true'
   
 runs:
     using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -4,21 +4,46 @@ description: 'Download the Kernel source to build a kmod or dmks in actuated'
 branding:
   icon: 'arrow-right-circle'
   color: 'gray-dark'
+  
+inputs:
+  cache:
+    description: Whether to enable caching for the downloaded sources
+    required: false
+    default: 'false'
+  
 runs:
     using: 'composite'
     steps:
       - name: Install git if not present
         shell: bash
-        id: install-tmux
         run: |
            if ! [ -x "$(command -v git)" ]; then
             echo Installing git
             sudo apt update -qqqy && sudo apt install -qqqy git
            fi
+      
+      - name: Reset permissions of /usr/src for runner
+        shell: bash
+        run: |
+          sudo chown -R runner:docker /usr/src
+
+      - name: Store KERNEL_RELEASE
+        shell: bash
+        run: |
+          echo "KERNEL_RELEASE=$(uname -r)" >> $GITHUB_ENV
+      
+      - name: Cache Kernel sources
+        if: inputs.cache == 'true'
+        id: cache-kernel-sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/src/linux
+          key: ${{ runner.os }}-${{ runner.arch }}-${{env.KERNEL_RELEASE}}     
            
       - name: Clone Kernel sources and link to /usr/src/linux
         shell: bash
-        id: download-link-sources
+        if: ${{ steps.cache-kernel-sources.outputs.cache-hit != 'true' }}
         run: |
           sudo mkdir -p /usr/src
           sudo git clone --depth 1 --branch v$(uname -r) git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git /usr/src/linux


### PR DESCRIPTION
Also, leverage `runner.arch` from runner context: https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context

This is a draft, opened for discussions:
* whether we want to put caching inside the composite action itself
* whether we want to enable cache by default
* whether we want to add a small CI to test the composite action that needs to run on an actuated arm64 node